### PR TITLE
Smoother now-playing transitions

### DIFF
--- a/Nebula/modules/Sound-icon.css
+++ b/Nebula/modules/Sound-icon.css
@@ -63,8 +63,12 @@
       .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked]):hover
         .tab-icon-overlay {
         margin: 0px !important;
-        transition: opacity 0.1s ease-out, transform 0.1s ease-out !important;
+        transition: opacity 0.25s ease-out, transform 0.25s ease-out !important;
         transform: translate(6.9px, -6.9px) scale(0.69) !important;
+      }
+
+      .tabbrowser-tab:is([soundplaying], [muted], [activemedia-blocked]) .tab-icon-overlay {
+        transition: opacity 0.25s ease-in, transform 0.25s ease-in !important;
       }
     }
   


### PR DESCRIPTION
Suggestion: Increase the transition time and another transition addition when the element is no longer hovered over. 

I've added a recording on how it's set-up. One difference to the proposed change is the translate() as I'm using the Compact tabs title mod.

https://github.com/user-attachments/assets/5fa0104b-4181-4bb8-8529-c621e7adfee9

