### PR TITLE
Centered urlbar & Reroll to normal tab corners.

### DIFF
--- a/Nebula/modules/General-UI.css
+++ b/Nebula/modules/General-UI.css
@@ -3,10 +3,6 @@
   --attention-dot-color: transparent !important;
 }
 
-/* make websites rounded */
-#tabbrowser-tabpanels {
-    clip-path: inset(0 round 10px);
-}
 
 browser[transparent='true'] {
     background: rgba(0,0,0,0) !important;

--- a/Nebula/modules/URLbar.css
+++ b/Nebula/modules/URLbar.css
@@ -106,3 +106,9 @@
     0% { background-position: 0% 50%; }
     100% { background-position: -300% 50%; } /* Move smoothly across */
   }
+
+  /* Centered URL bar Text*/
+#urlbar .urlbar-input,
+.urlbar-input-container{
+  text-align: center !important; 
+}


### PR DESCRIPTION
Makes the URL bar texts centered.
Removed clip path on website tabs to prevent conflicts with [#6302](https://github.com/zen-browser/desktop/issues/6302#issuecomment-2711579109)