### PR TITLE
chore(Readme): Updated Readme with MacOs comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@
 **Quick note:** If you want a video tutorial for the installation process then it is there on a youtube video someone made about it: https://www.youtube.com/watch?v=ysXRr6GAsNc&t=9s
 
 ### 🧊 Nix Installation
+
+>[!WARNING]
+> This installation method is for **Linux/MacOs users Only** using [Nix](https://nixos.org/) and [home-manager](https://github.com/nix-community/home-manager).
+> If you're using `Windows`, read the normal installation process.
+
 <details>
 <summary>‼️ Click here for Nix installation process</summary>
-> ⚠️ **Note for Windows and macOS users:**  
-> This installation method is for **Linux users** using [Nix](https://nixos.org/) and **home-manager**.  
-> If you're using **Windows** or **macOS**, read the normal installation process.
+
 
 This repo includes a **Nix flake** that provides a `home-manager` module to install **Nebula** for **Zen Browser** declaratively.
 


### PR DESCRIPTION
Nix is Also available on MacOs so this will work for them too. Just wanna make sure if someone using MacOs can confirm the path `"Library/Application\ Support/zen/Profiles"` is correct for them.

Also used git's readme warning style, (you can edit the warning part as you may like).
This pr is just to address that flake will work for mac users also. 🍻 