### PR TITLE
Fix for hovering title bar activating #browser::after

### DIFF
--- a/Nebula/modules/Sidebar.css
+++ b/Nebula/modules/Sidebar.css
@@ -61,7 +61,7 @@ body:has([zen-compact-mode="true"]) #titlebar {
   transition: left 0.2s cubic-bezier(0.175, 0.585, 0.32, 1.1), opacity 0.2s ease, filter 0.2s ease !important;
 }
 
-body:has([zen-compact-mode="true"] [zen-user-show=""], [zen-compact-mode="true"] [zen-has-hover="true"]) #browser::after {
+body:has([zen-compact-mode="true"] [zen-user-show=""], [zen-compact-mode="true"] #navigator-toolbox[zen-has-hover="true"]) #browser::after {
   opacity: 1 !important;
   left: var(--zen-element-separation) !important;
 }


### PR DESCRIPTION
When multiple toolbars are used, hovering over either of them activates the #browser::after element since hovering either of them gives them the zen-has-hover attribute. I changed line 64 in Sidebar.css so that only navigator-toolbox would activate this effect.

PS: The height and the padding of this element is different from the default as I am using the 'Smaller Compact Mode' mod, and set the following in my userChrome file: #browser::after { margin-top: 10vh !important; height: 73vh !important; } Maybe this could be a about:config option for other people that may be using this mod as well? Preferrably with better chosen values, since i just eyeballed these values until they looked ok for my device