### PR TITLE
Fix URLbar suggestions not displaying due to inverted height constraints

### DIFF
--- a/Nebula/modules/URLbar.css
+++ b/Nebula/modules/URLbar.css
@@ -156,8 +156,9 @@
 
 /* Open URL Bar State */
 #urlbar[open] .urlbarView {
-  min-height: 280px !important;
-  max-height: 73px !important;
+  min-height: 73px !important;
+  max-height: 280px !important;
+  overflow-y: auto !important;
   transition: min-height 0.2s ease, max-height 0.2s ease !important;
 }
 


### PR DESCRIPTION
## Issue
URL bar dropdown suggestions were not visible after opening the address bar. The suggestions were being rendered but positioned below the visible area.

## Root Cause
The `.urlbarView` had impossible CSS constraints:
- `min-height: 280px` (must be at least 280px)
- `max-height: 73px` (cannot exceed 73px)

When min-height > max-height, CSS uses min-height, causing the 280px element to render with only 73px visible viewport.

## Fix
- Corrected min-height to 73px (minimum for 1-2 items)
- Corrected max-height to 280px (maximum for 5+ items)  
- Added overflow-y: auto to enable scrolling when needed

This maintains all existing animations and styling while fixing visibility.

Fixes #277