### PR TITLE
Bug Fix: Findbar Visibility in Zen-Nebula Theme

### DIFF
--- a/Nebula/modules/Sidebar.css
+++ b/Nebula/modules/Sidebar.css
@@ -307,18 +307,18 @@ findbar {
     transition: opacity 0.2s ease, width 0.5s ease !important;
 }
 
-:has(.browserSidebarContainer.deck-selected > .browserContainer > findbar:not([hidden="true"])) #zen-tabbox-wrapper::before {
+:has(.browserSidebarContainer.deck-selected > .browserContainer > findbar:not([hidden])) #zen-tabbox-wrapper::before {
     opacity: 1 !important;
     width: 90.05%;
 }
           
-findbar:not([hidden="true"]) {
+findbar:not([hidden]) {
     visibility: visible !important;
     animation: findbar-show-animation 0.3s ease-out forwards !important;
 }
 
 
-findbar[hidden="true"] {
+findbar[hidden] {
     opacity: 0 !important;
     transform: scale(0.95) !important;
     pointer-events: none !important;


### PR DESCRIPTION
### 🛠 Bug Fix: Findbar Visibility in Zen-Nebula Theme

This PR fixes an issue where the **Findbar** in the Zen-Nebula theme did not fully disappear after closing.  
The patch ensures the bar now hides completely once dismissed, restoring expected behavior and visual consistency.
